### PR TITLE
gvisor: omit platform code from coverage instrumentation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Google Inc.
  Ioana-Ruxandra Stancioi
  Stefano Duo
  Aleksandr Nogikh
+ Dean Deng
 Baozeng Ding
 Lorenzo Stoakes
 Jeremy Huang

--- a/pkg/build/gvisor.go
+++ b/pkg/build/gvisor.go
@@ -21,7 +21,9 @@ func (gvisor gvisor) build(params *Params) error {
 	args := []string{"build", "--verbose_failures"}
 	outBinary := ""
 	if strings.Contains(config, " -cover ") {
-		args = append(args, []string{"--collect_code_coverage", "--instrumentation_filter=//pkg/..."}...)
+		args = append(args, []string{
+			"--collect_code_coverage",
+			"--instrumentation_filter=//pkg/...,-//pkg/sentry/platform/..."}...)
 	}
 	if strings.Contains(config, " -race ") {
 		args = append(args, "--features=race", "//runsc:runsc-race")


### PR DESCRIPTION
Collecting coverage in platform/ring0 code causes the kvm platform to
crash, possibly due torestrictions on the address space that coverage
data is violating.

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
